### PR TITLE
change argument of value to use flag instead

### DIFF
--- a/cmd/config/internal/commands/cmdcreatesetter.go
+++ b/cmd/config/internal/commands/cmdcreatesetter.go
@@ -20,7 +20,7 @@ import (
 func NewCreateSetterRunner(parent string) *CreateSetterRunner {
 	r := &CreateSetterRunner{}
 	set := &cobra.Command{
-		Use:     "create-setter DIR NAME --value VALUE",
+		Use:     "create-setter DIR NAME VALUE",
 		Args:    cobra.RangeArgs(2, 3),
 		Short:   commands.CreateSetterShort,
 		Long:    commands.CreateSetterLong,
@@ -29,7 +29,7 @@ func NewCreateSetterRunner(parent string) *CreateSetterRunner {
 		RunE:    r.runE,
 	}
 	set.Flags().StringVar(&r.Set.SetPartialField.Setter.Value, "value", "",
-		"optional flag, the value of the setter to be set to")
+		"optional flag, alternative to specifying the value as an argument. e.g. used to specify values that start with '-'")
 	set.Flags().StringVar(&r.Set.SetPartialField.SetBy, "set-by", "",
 		"record who the field was default by.")
 	set.Flags().StringVar(&r.Set.SetPartialField.Description, "description", "",
@@ -75,7 +75,7 @@ func (r *CreateSetterRunner) runE(c *cobra.Command, args []string) error {
 }
 
 func (r *CreateSetterRunner) preRunE(c *cobra.Command, args []string) error {
-	valueSetFromFlag := isFlagSet("value", c)
+	valueSetFromFlag := c.Flag("value").Changed
 	var err error
 	r.Set.SetPartialField.Setter.Name = args[1]
 	r.CreateSetter.Name = args[1]
@@ -91,7 +91,7 @@ func (r *CreateSetterRunner) preRunE(c *cobra.Command, args []string) error {
 	}
 
 	if setterVersion == "" {
-		if len(args) < 2 || !valueSetFromFlag && len(args) < 3 {
+		if len(args) < 2 || !c.Flag("value").Changed && len(args) < 3 {
 			setterVersion = "v1"
 		} else if err := initSetterVersion(c, args); err != nil {
 			return err

--- a/cmd/config/internal/commands/cmdcreatesetter_test.go
+++ b/cmd/config/internal/commands/cmdcreatesetter_test.go
@@ -202,7 +202,7 @@ kind: Deployment
 metadata:
   name: nginx-deployment
 spec:
-  replicas: 3 # {"$ref":"#/definitions/io.k8s.cli.setters.replicas"}
+  replicas: 3 # {"$openapi":"replicas"}
  `,
 		},
 	}

--- a/cmd/config/internal/commands/cmdcreatesetter_test.go
+++ b/cmd/config/internal/commands/cmdcreatesetter_test.go
@@ -168,6 +168,43 @@ spec:
   - "a" # {"$openapi":"list"}
  `,
 		},
+		{
+			name: "add replicas with value set by flag",
+			args: []string{"replicas", "--value", "3", "--description", "hello world", "--set-by", "me"},
+			input: `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  replicas: 3
+ `,
+			inputOpenAPI: `
+apiVersion: v1alpha1
+kind: Example
+`,
+			expectedOpenAPI: `
+apiVersion: v1alpha1
+kind: Example
+openAPI:
+  definitions:
+    io.k8s.cli.setters.replicas:
+      description: hello world
+      x-k8s-cli:
+        setter:
+          name: replicas
+          value: "3"
+          setBy: me
+ `,
+			expectedResources: `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  replicas: 3 # {"$ref":"#/definitions/io.k8s.cli.setters.replicas"}
+ `,
+		},
 	}
 	for i := range tests {
 		test := tests[i]

--- a/cmd/config/internal/commands/cmdset.go
+++ b/cmd/config/internal/commands/cmdset.go
@@ -79,7 +79,7 @@ func initSetterVersion(c *cobra.Command, args []string) error {
 }
 
 func (r *SetRunner) preRunE(c *cobra.Command, args []string) error {
-	valueFlagSet := isFlagSet("values", c)
+	valueFlagSet := c.Flag("values").Changed
 
 	if valueFlagSet && len(args) > 2 {
 		return errors.Errorf("value should set either from flag or arg")
@@ -90,7 +90,7 @@ func (r *SetRunner) preRunE(c *cobra.Command, args []string) error {
 		r.Lookup.Name = args[1]
 	}
 
-	if isFlagSet("values", c) && len(r.Values) == 1 {
+	if valueFlagSet {
 		r.Perform.Value = r.Values[0]
 	} else if len(args) > 2 {
 		r.Perform.Value = args[2]
@@ -136,7 +136,7 @@ func (r *SetRunner) runE(c *cobra.Command, args []string) error {
 		fmt.Fprintf(c.OutOrStdout(), "set %d fields\n", count)
 		return handleError(c, err)
 	}
-	if len(args) > 2 || isFlagSet("values", c) {
+	if len(args) > 2 || c.Flag("values").Changed {
 		return handleError(c, r.perform(c, args))
 	}
 	return handleError(c, lookup(r.Lookup, c, args))

--- a/cmd/config/internal/commands/cmdset.go
+++ b/cmd/config/internal/commands/cmdset.go
@@ -11,6 +11,7 @@ import (
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/kustomize/cmd/config/ext"
 	"sigs.k8s.io/kustomize/cmd/config/internal/generateddocs/commands"
+	"sigs.k8s.io/kustomize/kyaml/errors"
 	"sigs.k8s.io/kustomize/kyaml/kio"
 	"sigs.k8s.io/kustomize/kyaml/setters"
 	"sigs.k8s.io/kustomize/kyaml/setters2/settersutil"
@@ -20,8 +21,8 @@ import (
 func NewSetRunner(parent string) *SetRunner {
 	r := &SetRunner{}
 	c := &cobra.Command{
-		Use:     "set DIR NAME [VALUE]",
-		Args:    cobra.MinimumNArgs(3),
+		Use:     "set DIR NAME --values [VALUE]",
+		Args:    cobra.MinimumNArgs(2),
 		Short:   commands.SetShort,
 		Long:    commands.SetLong,
 		Example: commands.SetExamples,
@@ -30,6 +31,8 @@ func NewSetRunner(parent string) *SetRunner {
 	}
 	fixDocs(parent, c)
 	r.Command = c
+	c.Flags().StringArrayVar(&r.Values, "values", []string{},
+		"optional flag, the values of the setter to be set to")
 	c.Flags().StringVar(&r.Perform.SetBy, "set-by", "",
 		"annotate the field with who set it")
 	c.Flags().StringVar(&r.Perform.Description, "description", "",
@@ -53,6 +56,7 @@ type SetRunner struct {
 	Perform     setters.PerformSetters
 	Set         settersutil.FieldSetter
 	OpenAPIFile string
+	Values      []string
 }
 
 func initSetterVersion(c *cobra.Command, args []string) error {
@@ -75,16 +79,25 @@ func initSetterVersion(c *cobra.Command, args []string) error {
 }
 
 func (r *SetRunner) preRunE(c *cobra.Command, args []string) error {
+	valueFlagSet := isFlagSet("values", c)
+
+	if valueFlagSet && len(args) > 2 {
+		return errors.Errorf("value should set either from flag or arg")
+	}
+
 	if len(args) > 1 {
 		r.Perform.Name = args[1]
 		r.Lookup.Name = args[1]
 	}
-	if len(args) > 2 {
+
+	if isFlagSet("values", c) && len(r.Values) == 1 {
+		r.Perform.Value = r.Values[0]
+	} else if len(args) > 2 {
 		r.Perform.Value = args[2]
 	}
 
 	if setterVersion == "" {
-		if len(args) < 3 {
+		if len(args) < 2 || len(args) < 3 && !valueFlagSet {
 			setterVersion = "v1"
 		} else if err := initSetterVersion(c, args); err != nil {
 			return err
@@ -93,12 +106,19 @@ func (r *SetRunner) preRunE(c *cobra.Command, args []string) error {
 	if setterVersion == "v2" {
 		var err error
 		r.Set.Name = args[1]
-		r.Set.Value = args[2]
+		if valueFlagSet {
+			r.Set.Value = r.Values[0]
+		} else {
+			r.Set.Value = args[2]
+		}
 
 		// set remaining values as list values
-		if len(args) > 3 {
+		if valueFlagSet && len(r.Values) > 1 {
+			r.Set.ListValues = r.Values[1:]
+		} else if !valueFlagSet && len(args) > 3 {
 			r.Set.ListValues = args[3:]
 		}
+
 		r.Set.Description = r.Perform.Description
 		r.Set.SetBy = r.Perform.SetBy
 		r.OpenAPIFile, err = ext.GetOpenAPIFile(args)
@@ -116,7 +136,7 @@ func (r *SetRunner) runE(c *cobra.Command, args []string) error {
 		fmt.Fprintf(c.OutOrStdout(), "set %d fields\n", count)
 		return handleError(c, err)
 	}
-	if len(args) == 3 {
+	if len(args) > 2 || isFlagSet("values", c) {
 		return handleError(c, r.perform(c, args))
 	}
 	return handleError(c, lookup(r.Lookup, c, args))

--- a/cmd/config/internal/commands/cmdset_test.go
+++ b/cmd/config/internal/commands/cmdset_test.go
@@ -75,6 +75,54 @@ spec:
  `,
 		},
 		{
+			name: "validate length of argument",
+			args: []string{"--description", "hi there", "--set-by", "pw"},
+			inputOpenAPI: `
+apiVersion: v1alpha1
+kind: Example
+openAPI:
+  definitions:
+    io.k8s.cli.setters.replicas:
+      description: hello world
+      x-k8s-cli:
+        setter:
+          name: replicas
+          value: "3"
+          setBy: me
+ `,
+			input: `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  replicas: 3 # {"$ref":"#/definitions/io.k8s.cli.setters.replicas"}
+ `,
+			expectedOpenAPI: `
+apiVersion: v1alpha1
+kind: Example
+openAPI:
+  definitions:
+    io.k8s.cli.setters.replicas:
+      description: hello world
+      x-k8s-cli:
+        setter:
+          name: replicas
+          value: "3"
+          setBy: me
+ `,
+			expectedResources: `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  replicas: 3 # {"$ref":"#/definitions/io.k8s.cli.setters.replicas"}
+ `,
+			errMsg: "requires at least 2 arg(s), only received 1",
+		},
+
+		{
 			name: "set replicas no description",
 			args: []string{"replicas", "4"},
 			out:  "set 1 fields\n",
@@ -121,7 +169,7 @@ spec:
  `,
 		},
 		{
-			name: "set image",
+			name: "set image with value",
 			args: []string{"tag", "1.8.1"},
 			out:  "set 1 fields\n",
 			inputOpenAPI: `
@@ -407,6 +455,205 @@ spec:
 		{
 			name: "validate openAPI list values",
 			args: []string{"list", "10", "hi", "true"},
+			inputOpenAPI: `
+kind: Kptfile
+openAPI:
+  definitions:
+    io.k8s.cli.setters.list:
+      type: array
+      maxItems: 2
+      items:
+        type: integer
+      x-k8s-cli:
+        setter:
+          name: list
+          listValues:
+          - 0
+ `,
+			input: `
+apiVersion: example.com/v1beta1
+kind: Example
+spec:
+  list: # {"$ref":"#/definitions/io.k8s.cli.setters.list"}
+  - 0
+ `,
+			expectedOpenAPI: `
+kind: Kptfile
+openAPI:
+  definitions:
+    io.k8s.cli.setters.list:
+      type: array
+      maxItems: 2
+      items:
+        type: integer
+      x-k8s-cli:
+        setter:
+          name: list
+          listValues:
+          - 0
+ `,
+			expectedResources: `
+apiVersion: example.com/v1beta1
+kind: Example
+spec:
+  list: # {"$ref":"#/definitions/io.k8s.cli.setters.list"}
+  - 0
+ `,
+			errMsg: `list in body must be of type integer: "string"
+list in body must be of type integer: "boolean"
+list in body should have at most 2 items`,
+		},
+
+		{
+			name: "set replicas with value set by flag",
+			args: []string{"replicas", "--values", "4", "--description", "hi there"},
+			out:  "set 1 fields\n",
+			inputOpenAPI: `
+apiVersion: v1alpha1
+kind: Example
+openAPI:
+  definitions:
+    io.k8s.cli.setters.replicas:
+      description: hello world
+      x-k8s-cli:
+        setter:
+          name: replicas
+          value: "3"
+          setBy: me
+ `,
+			input: `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  replicas: 3 # {"$ref":"#/definitions/io.k8s.cli.setters.replicas"}
+ `,
+			expectedOpenAPI: `
+apiVersion: v1alpha1
+kind: Example
+openAPI:
+  definitions:
+    io.k8s.cli.setters.replicas:
+      description: hi there
+      x-k8s-cli:
+        setter:
+          name: replicas
+          value: "4"
+ `,
+			expectedResources: `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  replicas: 4 # {"$ref":"#/definitions/io.k8s.cli.setters.replicas"}
+ `,
+		},
+
+		{
+			name: "validate values set from either flag or arg",
+			args: []string{"replicas", "4", "--values", "4", "--description", "hi there"},
+			inputOpenAPI: `
+apiVersion: v1alpha1
+kind: Example
+openAPI:
+  definitions:
+    io.k8s.cli.setters.replicas:
+      description: hello world
+      x-k8s-cli:
+        setter:
+          name: replicas
+          value: "3"
+          setBy: me
+ `,
+			input: `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  replicas: 3 # {"$ref":"#/definitions/io.k8s.cli.setters.replicas"}
+ `,
+			expectedOpenAPI: `
+apiVersion: v1alpha1
+kind: Example
+openAPI:
+  definitions:
+    io.k8s.cli.setters.replicas:
+      description: hello world
+      x-k8s-cli:
+        setter:
+          name: replicas
+          value: "3"
+          setBy: me
+ `,
+			expectedResources: `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  replicas: 3 # {"$ref":"#/definitions/io.k8s.cli.setters.replicas"}
+ `,
+			errMsg: `value should set either from flag or arg`,
+		},
+
+		{
+			name: "openAPI list values set by flag success",
+			args: []string{"list", "--values", "10", "--values", "11"},
+			out:  "set 1 fields\n",
+			inputOpenAPI: `
+kind: Kptfile
+openAPI:
+  definitions:
+    io.k8s.cli.setters.list:
+      type: array
+      maxItems: 2
+      items:
+        type: integer
+      x-k8s-cli:
+        setter:
+          name: list
+          listValues:
+          - 0
+ `,
+			input: `
+apiVersion: example.com/v1beta1
+kind: Example
+spec:
+  list: # {"$ref":"#/definitions/io.k8s.cli.setters.list"}
+  - 0
+ `,
+			expectedOpenAPI: `
+kind: Kptfile
+openAPI:
+  definitions:
+    io.k8s.cli.setters.list:
+      type: array
+      maxItems: 2
+      items:
+        type: integer
+      x-k8s-cli:
+        setter:
+          name: list
+          listValues:
+          - "10"
+          - "11"
+ `,
+			expectedResources: `
+apiVersion: example.com/v1beta1
+kind: Example
+spec:
+  list: # {"$ref":"#/definitions/io.k8s.cli.setters.list"}
+  - "10"
+  - "11"
+ `,
+		},
+
+		{
+			name: "validate openAPI list values set by flag error",
+			args: []string{"list", "--values", "10", "--values", "hi", "--values", "true"},
 			inputOpenAPI: `
 kind: Kptfile
 openAPI:

--- a/cmd/config/internal/commands/util.go
+++ b/cmd/config/internal/commands/util.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/go-errors/errors"
 	"github.com/spf13/cobra"
-	flag "github.com/spf13/pflag"
 )
 
 // parseFieldPath parse a flag value into a field path
@@ -38,16 +37,6 @@ func parseFieldPath(path string) ([]string, error) {
 		newParts = append(newParts, p[0], p[1])
 	}
 	return newParts, nil
-}
-
-func isFlagSet(name string, c *cobra.Command) bool {
-	set := false
-	c.Flags().Visit(func(f *flag.Flag) {
-		if f.Name == name {
-			set = true
-		}
-	})
-	return set
 }
 
 func handleError(c *cobra.Command, err error) error {

--- a/cmd/config/internal/commands/util.go
+++ b/cmd/config/internal/commands/util.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/go-errors/errors"
 	"github.com/spf13/cobra"
+	flag "github.com/spf13/pflag"
 )
 
 // parseFieldPath parse a flag value into a field path
@@ -37,6 +38,16 @@ func parseFieldPath(path string) ([]string, error) {
 		newParts = append(newParts, p[0], p[1])
 	}
 	return newParts, nil
+}
+
+func isFlagSet(name string, c *cobra.Command) bool {
+	set := false
+	c.Flags().Visit(func(f *flag.Flag) {
+		if f.Name == name {
+			set = true
+		}
+	})
+	return set
 }
 
 func handleError(c *cobra.Command, err error) error {


### PR DESCRIPTION
This PR changes argument of value to use flag instead. So the interface for setting would changed:
before: set DIR NAME VALUE/LIST OF VALUE
after: set DIR NAME --value VALUE/LIST OF VALUE

With this change, the value starting with hyphen could be correctly parsed. 
see issue:
https://github.com/GoogleContainerTools/kpt/issues/518